### PR TITLE
updated deprecated class

### DIFF
--- a/lib/models/turkee_task.rb
+++ b/lib/models/turkee_task.rb
@@ -244,7 +244,7 @@ module Turkee
 
     # Returns the default url of the model's :new route
     def self.form_url(host, typ, params = {})
-      @app ||= ActionController::Integration::Session.new(Rails.application)
+      @app ||= ActionDispatch::Integration::Session.new(Rails.application)
       url = (host + @app.send("new_#{typ.to_s.underscore}_path"))
       full_url(url, params)
     end


### PR DESCRIPTION
this removes:
DEPRECATION WARNING: cl is deprecated and will be removed, use ActionDispatch::Integration instead.
(called from form_url at ~/.rvm/gems/ruby-2.0.0-p353/bundler/gems/turkee-8c37590970e0/lib/models/turkee_task.rb:261)
